### PR TITLE
fix: improve cookie data handling and JSON output

### DIFF
--- a/browsingdata/cookie.go
+++ b/browsingdata/cookie.go
@@ -13,9 +13,9 @@ import (
 	"github.com/ultra-supara/cookie/HackChromeData/util"
 )
 
-type ChromiumCookie []cookie
+type ChromiumCookie []Cookie
 
-type cookie struct {
+type Cookie struct {
 	Host         string `json:"host"`
 	Path         string `json:"path"`
 	KeyName      string `json:"keyname"`
@@ -29,7 +29,7 @@ type cookie struct {
 	ExpireDate   time.Time `json:"expire_date"`
 }
 
-func GetCookie(base64MasterKey string, filepath string) ([]cookie, error) {
+func GetCookie(base64MasterKey string, filepath string) ([]Cookie, error) {
 	// Decode masterkey
 	key, err := base64.StdEncoding.DecodeString(base64MasterKey)
 	if err != nil {
@@ -52,7 +52,7 @@ func GetCookie(base64MasterKey string, filepath string) ([]cookie, error) {
 	}
 	defer rows.Close()
 
-	var c []cookie
+	var c []Cookie
 	for rows.Next() {
 		var (
 			hostKey, host, path                           string
@@ -65,7 +65,7 @@ func GetCookie(base64MasterKey string, filepath string) ([]cookie, error) {
 			log.Println(err)
 		}
 
-		cookie := cookie{
+		cookie := Cookie{
 			KeyName:      hostKey,
 			Host:         host,
 			Path:         path,
@@ -88,7 +88,11 @@ func GetCookie(base64MasterKey string, filepath string) ([]cookie, error) {
 				log.Println(err)
 			}
 		}
-		cookie.Value = string(value)
+		if value != nil {
+			cookie.Value = base64.StdEncoding.EncodeToString(value)
+		} else {
+			cookie.Value = ""
+		}
 		c = append(c, cookie)
 	}
 	return c, nil

--- a/main.go
+++ b/main.go
@@ -53,9 +53,16 @@ func main() {
 		if err != nil {
 			log.Fatalf("Failed to get logain data: %v", err)
 		}
-		for _, v := range c {
-			j, _ := json.Marshal(v)
-			fmt.Println(string(j))
+		output := struct {
+			Cookies []browsingdata.Cookie `json:"cookies"`
+		}{
+			Cookies: c,
+		}
+
+		encoder := json.NewEncoder(os.Stdout)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(output); err != nil {
+			log.Fatalf("Failed to encode cookie data: %v", err)
 		}
 
 	case "logindata":


### PR DESCRIPTION
## Changes

- Fix Unicode replacement character issues using Base64 encoding for cookie values
- Improve JSON output formatting with proper indentation
- Make Cookie struct public for better API
- Enhance error handling in JSON encoding

## Problem
- Unicode replacement characters (\ufffd) appeared in cookie values
- JSON output was not properly formatted
- Cookie struct was not accessible from outside the package

## Solution
- Implement Base64 encoding for binary cookie data
- Add structured JSON output with proper indentation
- Make Cookie struct public and improve error handling

## How to check

```sh
go run main.go -kind cookie -targetpath "/path/to/Library/Application Support/Google/Chrome/Default/Cookies" -localstate "/path/to/Library/Application Support/Google/Chrome/Local State"
```